### PR TITLE
add new DesktopEnv for iTerm on MacOS

### DIFF
--- a/plugin/src/de/bastiankrol/startexplorer/PluginContext.java
+++ b/plugin/src/de/bastiankrol/startexplorer/PluginContext.java
@@ -16,7 +16,7 @@ import de.bastiankrol.startexplorer.variables.VariableManager;
 
 /**
  * Container for some singletons that are used by this plug-in.
- * 
+ *
  * @author Bastian Krol
  */
 public class PluginContext
@@ -71,7 +71,7 @@ public class PluginContext
 
   /**
    * Returns the shared instance of RuntimeExecCalls
-   * 
+   *
    * @return the shared instance of RuntimeExecCalls
    */
   public IRuntimeExecCalls getRuntimeExecCalls()
@@ -133,6 +133,8 @@ public class PluginContext
         return RuntimeExecCallsFactory.linuxMate();
       case MAC_OS:
         return RuntimeExecCallsFactory.macOs();
+      case MAC_OS_ITERM:
+        return RuntimeExecCallsFactory.macOsITerm();
       case LINUX_UNKNOWN:
         // fall through
       case UNKNOWN:
@@ -156,7 +158,7 @@ public class PluginContext
 
   /**
    * Returns the shared instance of the Validator
-   * 
+   *
    * @return the shared instance of the Validator
    */
   public Validator getValidator()

--- a/plugin/src/de/bastiankrol/startexplorer/crossplatform/DesktopEnvironment.java
+++ b/plugin/src/de/bastiankrol/startexplorer/crossplatform/DesktopEnvironment.java
@@ -18,6 +18,7 @@ public enum DesktopEnvironment
   LINUX_MATE(OperatingSystem.LINUX, "MATE"), //
   LINUX_UNKNOWN(OperatingSystem.LINUX, "Unknown"), //
   MAC_OS(OperatingSystem.MAC_OS), //
+  MAC_OS_ITERM(OperatingSystem.MAC_OS, "iTerm"), //
   UNKNOWN(OperatingSystem.UNKNOWN);
 
   private static final Map<String, DesktopEnvironment> LABEL_TO_VALUE;

--- a/plugin/src/de/bastiankrol/startexplorer/crossplatform/RuntimeExecCallsFactory.java
+++ b/plugin/src/de/bastiankrol/startexplorer/crossplatform/RuntimeExecCallsFactory.java
@@ -57,6 +57,11 @@ public class RuntimeExecCallsFactory
     return new RuntimeExecCallsMacOs();
   }
 
+  public static RuntimeExecCallsMacOsITerm macOsITerm()
+  {
+    return new RuntimeExecCallsMacOsITerm();
+  }
+
   public static RuntimeExecCallsCustom custom(
       CustomDesktopEnvironmentContainer container)
   {

--- a/plugin/src/de/bastiankrol/startexplorer/crossplatform/RuntimeExecCallsMacOsITerm.java
+++ b/plugin/src/de/bastiankrol/startexplorer/crossplatform/RuntimeExecCallsMacOsITerm.java
@@ -1,0 +1,37 @@
+package de.bastiankrol.startexplorer.crossplatform;
+
+import java.io.File;
+
+/**
+ * Runtime exec calls for Mac OS. Thanks to Yevgeniy M.
+ *
+ * @author Bastian Krol
+ */
+class RuntimeExecCallsMacOsITerm extends RuntimeExecCallsMacOs
+{
+
+  /**
+   * Creates a new instance and initializes the {@link RuntimeExecDelegate}.
+   */
+  RuntimeExecCallsMacOsITerm()
+  {
+    super();
+  }
+
+  /**
+   * Creates a new instance with the given {@link RuntimeExecDelegate}.
+   *
+   * @param delegate the RuntimeExecDelegate to use
+   */
+  RuntimeExecCallsMacOsITerm(RuntimeExecDelegate delegate)
+  {
+    super(delegate);
+  }
+
+  @Override
+  String[] getCommandForStartShell(File file)
+  {
+    return new String[] { "open", "-a", "/Applications/iTerm.app",
+        getPath(file) };
+  }
+}


### PR DESCRIPTION
As I only work with iTerm on OSX i'd like to jump into this terminal instead of Default Terminal App.